### PR TITLE
Function call improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Go-based language interpreter for a toy programming language called "monke" (pro
 
 Based on ["Writing An Interpreter In Go" by Thorsten Ball](https://interpreterbook.com/) with some extra improvements, such as:
 - Additional built in functions for the Hash and Array objects (inspired from other languages such as Ruby)
+- Standard Object#Function invocation: `someObject.someMethod()` as opposed to `someMethod(someObject)`
 - Index reassignment for Arrays and Hashes
 - Base project refactors
 - Additional dev notes for each interpreter component
@@ -132,13 +133,16 @@ Hello World
 4
 ~> len(x)
 3
+::Array#len alternative
+~> y.len()
+4
 
 ::Array#first
-~> first(x)
+~> x.first()
 1
 
 ::Array#last
-~> last(y)
+~> y.last()
 4
 
 ::Array#[]
@@ -154,13 +158,13 @@ Hello!
 ::Array#map
 ~> let arr = [1,2,3]
 ~> let addTwo = fn(x) { x + 2; }
-~> let res = map(arr, addTwo)
+~> let res = arr.map(addTwo)
 ~> res
 [3, 4, 5]
 
 ::Array#pop
 ~> let arr = [1,2,3]
-~> let popVal = pop(arr)
+~> let popVal = arr.pop()
 ~> arr
 [1, 2]
 ~> popVal
@@ -168,7 +172,7 @@ Hello!
 
 ::Array#shift
 ~> let tb = ["Tom", "Bombadil"]
-~> let firstName = shift(tb)
+~> let firstName = tb.shift()
 ~> firstName
 Tom
 ~> tb
@@ -176,11 +180,11 @@ Tom
 
 ::Array#slice
 ~> let animals = ["ant", "bison", "camel", "duck", "elephant"];
-~> slice(animals, 2)
+~> animals.slice(2)
 [camel, duck, elephant]
-~> slice(animals, 2, 4)
+~> animals.slice(2, 4)
 [camel, duck]
-~> slice(animals)
+~> animals.slice()
 [ant, bison, camel, duck, elephant]
 ```
 
@@ -205,22 +209,22 @@ John
 21
 
 ::Hash#valuesAt
-~> valuesAt(person, "age", "name")
+~> person.valuesAt("age", "name")
 [21, John]
 
 ::Hash#toArray
-~> toArray(person)
+~> person.toArray()
 [name, John, age, 21]
 
 ::Hash#delete
-~> delete(person, "age")
+~> person.delete("age")
 {name: John, null: null}
 ~> person["age"]
 null
 
 ::Hash#dig
 ~> let person = { "name": "Tom Bombadil", "clothes": { "shoes": "yellow boots" } };
-~> dig(person, "clothes", "shoes")
+~> person.dig("clothes", "shoes")
 yellow boots
 
 ```

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -418,10 +418,11 @@ func (hl *HashLiteral) String() string {
 }
 
 type InternalFunctionCall struct {
-	Token      token.Token // the '.' token
-	CallerType string      // Array, Hash
-	Function   Expression  // idenfifier or function literal
-	Arguments  []Expression
+	Token              token.Token  // the '.' token
+	CallerIdentifier   *Identifier  //someArray, someHash, etc
+	CallerType         string       // Array, Hash
+	FunctionIdentifier *Identifier  // pop, delete, etc.
+	Arguments          []Expression //(1,2,3), (), etc.
 }
 
 func (ifc *InternalFunctionCall) expressionNode()      {}
@@ -435,9 +436,9 @@ func (ifc *InternalFunctionCall) String() string {
 		args = append(args, a.String())
 	}
 
-	out.WriteString(ifc.CallerType)        //Array, Hash
-	out.WriteString(ifc.Token.Literal)     // .
-	out.WriteString(ifc.Function.String()) // delete, pop
+	out.WriteString(ifc.CallerIdentifier.String())   //Array, Hash
+	out.WriteString(ifc.Token.Literal)               // .
+	out.WriteString(ifc.FunctionIdentifier.String()) // delete, pop
 	out.WriteString("(")
 	out.WriteString(strings.Join(args, ", ")) // args
 	out.WriteString(")")

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -416,3 +416,31 @@ func (hl *HashLiteral) String() string {
 
 	return out.String()
 }
+
+type InternalFunctionCall struct {
+	Token      token.Token // the '.' token
+	CallerType string      // Array, Hash
+	Function   Expression  // idenfifier or function literal
+	Arguments  []Expression
+}
+
+func (ifc *InternalFunctionCall) expressionNode()      {}
+func (ifc *InternalFunctionCall) TokenLiteral() string { return ifc.Token.Literal }
+func (ifc *InternalFunctionCall) String() string {
+	var out bytes.Buffer
+
+	args := []string{}
+
+	for _, a := range ifc.Arguments {
+		args = append(args, a.String())
+	}
+
+	out.WriteString(ifc.CallerType)        //Array, Hash
+	out.WriteString(ifc.Token.Literal)     // .
+	out.WriteString(ifc.Function.String()) // delete, pop
+	out.WriteString("(")
+	out.WriteString(strings.Join(args, ", ")) // args
+	out.WriteString(")")
+
+	return out.String()
+}

--- a/ast/ast.go
+++ b/ast/ast.go
@@ -436,11 +436,11 @@ func (ifc *InternalFunctionCall) String() string {
 		args = append(args, a.String())
 	}
 
-	out.WriteString(ifc.CallerIdentifier.String())   //Array, Hash
+	out.WriteString(ifc.CallerIdentifier.String())   //someArray, someHash, etc
 	out.WriteString(ifc.Token.Literal)               // .
 	out.WriteString(ifc.FunctionIdentifier.String()) // delete, pop
 	out.WriteString("(")
-	out.WriteString(strings.Join(args, ", ")) // args
+	out.WriteString(strings.Join(args, ", ")) // (), (1,2,3), ("a", "b", "c"), etc
 	out.WriteString(")")
 
 	return out.String()

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -152,6 +152,10 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.HashLiteral:
 		return evalHashLiteral(node, env)
 
+	case *ast.InternalFunctionCall:
+		fmt.Println(node)
+		// return evalHashLiteral(node, env)
+
 	}
 
 	return nil

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -153,8 +153,31 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 		return evalHashLiteral(node, env)
 
 	case *ast.InternalFunctionCall:
-		fmt.Println(node)
-		// return evalHashLiteral(node, env)
+		// someArr, someHash
+		caller_ident := Eval(node.CallerIdentifier, env)
+
+		if isError(caller_ident) {
+			return caller_ident
+		}
+		// .pop(), .delete(), etc
+		func_ident := Eval(node.FunctionIdentifier, env)
+
+		if isError(func_ident) {
+			return caller_ident
+		}
+		// (1,2,3), ("a", "b", "c"), etc
+		args := evalExpressions(node.Arguments, env)
+
+		for _, arg := range args {
+			if isError(arg) {
+				return nil
+			}
+		}
+		//  ( someArr, (1,2,3) )
+		newArgs := append([]object.Object{caller_ident}, args...)
+
+		// call the function as usual builtInFunc(objectIdentifier, args)
+		return applyFunction(func_ident, newArgs)
 
 	}
 

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -951,3 +951,36 @@ func TestArraySliceFunction(t *testing.T) {
 		}
 	}
 }
+
+func TestArrayInternalFunctionCall(t *testing.T) {
+	expectedResults := [][]string{
+		{"camel", "duck", "elephant"},
+		{"camel", "duck"},
+		{"bison", "camel", "duck", "elephant"},
+		{"ant", "bison", "camel", "duck", "elephant"},
+	}
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{`let animals = ["ant", "bison", "camel", "duck", "elephant"]; animals.slice(2);`, expectedResults[0]},
+		{`let animals = ["ant", "bison", "camel", "duck", "elephant"]; animals.slice(2, 4);`, expectedResults[1]},
+		{`let animals = ["ant", "bison", "camel", "duck", "elephant"]; animals.slice(1, 5);`, expectedResults[2]},
+		{`let animals = ["ant", "bison", "camel", "duck", "elephant"]; animals.slice();`, expectedResults[3]},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		arr, isArray := evaluated.(*object.Array)
+
+		if !isArray {
+			t.Errorf("Expected an Array returned, got %T instead", arr.Type())
+		}
+
+		for _, val := range tt.expected {
+			if !contains(arr.Elements, val) {
+				t.Errorf("Invalid value found in array, expected to find: %s", val)
+			}
+		}
+	}
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -616,8 +616,11 @@ func TestHashKeyDeletions(t *testing.T) {
 		expected interface{}
 	}{
 		{`let hash = {"a": 2 }; delete(hash, "a"); hash["a"]`, nil},
+		{`let hash = {"a": 2 }; hash.delete("a"); hash["a"]`, nil},
 		{`let hash = {"a": 2, "b": 3 }; delete(hash, "b"); hash["b"]`, nil},
+		{`let hash = {"a": 2, "b": 3 }; hash.delete("b"); hash["b"]`, nil},
 		{`let hash = {"a": 2, "b":3, "c": 4 }; delete(hash, "a", "b"); hash["c"]`, 4},
+		{`let hash = {"a": 2, "b":3, "c": 4 }; hash.delete("a", "b"); hash["c"]`, 4},
 	}
 
 	for _, tt := range tests {
@@ -644,9 +647,13 @@ func TestHashValueRetrieval(t *testing.T) {
 		expected []interface{}
 	}{
 		{`let hash = {"a": 2 }; valuesAt(hash, "a");`, expected_results[0]},
+		{`let hash = {"a": 2 }; hash.valuesAt("a");`, expected_results[0]},
 		{`let hash = {"a": 2, "b": 3 };  valuesAt(hash, "a", "b")`, expected_results[1]},
+		{`let hash = {"a": 2, "b": 3 };  hash.valuesAt("a", "b")`, expected_results[1]},
 		{`let hash = {"a": 2, "b": 3 }; delete(hash, "b"); valuesAt(hash,"a","b") `, expected_results[2]},
+		{`let hash = {"a": 2, "b": 3 }; hash.delete("b"); hash.valuesAt("a","b") `, expected_results[2]},
 		{`let hash = {"a": 2, "b":3, "c": 4 }; delete(hash, "a", "b", "x"); valuesAt(hash, "a","b","c")`, expected_results[3]},
+		{`let hash = {"a": 2, "b":3, "c": 4 }; hash.delete("a", "b", "x"); hash.valuesAt("a","b","c")`, expected_results[3]},
 	}
 
 	for _, tt := range tests {
@@ -705,7 +712,9 @@ func TestHashToArrayConversion(t *testing.T) {
 		expected []interface{}
 	}{
 		{`let hash = {"a": 2 }; toArray(hash)`, expected_results[0]},
+		{`let hash = {"a": 2 }; hash.toArray()`, expected_results[0]},
 		{`let hash = {"a": 2, "b": 3 };  toArray(hash)`, expected_results[1]},
+		{`let hash = {"a": 2, "b": 3 };  hash.toArray()`, expected_results[1]},
 	}
 
 	for _, tt := range tests {
@@ -723,6 +732,7 @@ func TestHashDigging(t *testing.T) {
 		expected string
 	}{
 		{`let person = { "name": "Tom Bombadil", "clothes": { "shoes": "yellow boots" } }; dig(person, "clothes", "shoes");`, expected_results[0]},
+		{`let person = { "name": "Tom Bombadil", "clothes": { "shoes": "yellow boots" } }; person.dig("clothes", "shoes");`, expected_results[0]},
 	}
 
 	for _, tt := range tests {
@@ -780,7 +790,9 @@ func TestArrayMapFunction(t *testing.T) {
 		expected []interface{}
 	}{
 		{`let arr = [1,2,3]; let addTwo = fn(x) { x + 2; }; let arr = map(arr, addTwo); arr`, expectedResults[0]},
+		{`let arr = [1,2,3]; let addTwo = fn(x) { x + 2; }; let arr = arr.map(addTwo); arr`, expectedResults[0]},
 		{`let arr = [2,4,6]; let multiplyTwo = fn(x) { x * 2; }; let arr = map(arr, multiplyTwo); arr`, expectedResults[1]},
+		{`let arr = [2,4,6]; let multiplyTwo = fn(x) { x * 2; }; let arr = arr.map(multiplyTwo); arr`, expectedResults[1]},
 	}
 
 	for _, tt := range tests {
@@ -809,7 +821,9 @@ func TestArrayPopFunction(t *testing.T) {
 		expected []interface{}
 	}{
 		{`let arr = [1,2,3]; pop(arr); arr`, expectedResults[0]},
+		{`let arr = [1,2,3]; arr.pop(); arr`, expectedResults[0]},
 		{`let arr = [2,4,6]; pop(arr); arr`, expectedResults[1]},
+		{`let arr = [2,4,6]; arr.pop(); arr`, expectedResults[1]},
 	}
 
 	for _, tt := range tests {
@@ -834,8 +848,11 @@ func TestArrayPopFunctionReturn(t *testing.T) {
 		expected interface{}
 	}{
 		{`let arr = [1,2,3]; pop(arr);`, 3},
+		{`let arr = [1,2,3]; arr.pop();`, 3},
 		{`let arr = [2,4,6]; pop(arr);`, 6},
+		{`let arr = [2,4,6]; arr.pop();`, 6},
 		{`let arr = ["Frodo", "Baggins"]; pop(arr);`, "Baggins"},
+		{`let arr = ["Frodo", "Baggins"]; arr.pop();`, "Baggins"},
 	}
 
 	for _, tt := range tests {
@@ -869,7 +886,9 @@ func TestArrayShiftFunction(t *testing.T) {
 		expected []interface{}
 	}{
 		{`let arr = [1,2,3]; shift(arr); arr`, expectedResults[0]},
+		{`let arr = [1,2,3]; arr.shift(); arr`, expectedResults[0]},
 		{`let arr = [2,4,6]; shift(arr); arr`, expectedResults[1]},
+		{`let arr = [2,4,6]; arr.shift(); arr`, expectedResults[1]},
 	}
 
 	for _, tt := range tests {
@@ -894,8 +913,11 @@ func TestArrayShiftFunctionReturn(t *testing.T) {
 		expected interface{}
 	}{
 		{`let arr = [1,2,3]; shift(arr);`, 1},
+		{`let arr = [1,2,3]; arr.shift();`, 1},
 		{`let arr = [2,4,6]; shift(arr);`, 2},
+		{`let arr = [2,4,6]; arr.shift();`, 2},
 		{`let arr = ["Frodo", "Baggins"]; shift(arr);`, "Frodo"},
+		{`let arr = ["Frodo", "Baggins"]; arr.shift();`, "Frodo"},
 	}
 
 	for _, tt := range tests {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -114,6 +114,8 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.RBRACKET, l.ch)
 	case ':':
 		tok = newToken(token.COLON, l.ch)
+	case '.':
+		tok = newToken(token.DOT, l.ch)
 	case 0:
 		// reached EOF
 		tok.Literal = ""

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -44,6 +44,7 @@ func TestNextToken(t *testing.T) {
 	[1,2];
 	{"foo": "bar"}
 	hash["a"] = 2
+	arr.pop()
 	`
 	// Lets make sure we get back the correct tokens based on our input.
 	tests := []struct {
@@ -142,6 +143,11 @@ func TestNextToken(t *testing.T) {
 		{token.RBRACKET, "]"},
 		{token.ASSIGN, "="},
 		{token.INT, "2"},
+		{token.IDENT, "arr"},
+		{token.DOT, "."},
+		{token.IDENT, "pop"},
+		{token.LPAREN, "("},
+		{token.RPAREN, ")"},
 		{token.EOF, ""},
 	}
 	// Create a new lexer

--- a/token/token.go
+++ b/token/token.go
@@ -13,7 +13,7 @@ const (
 	IDENT  = "IDENT" // add, foobar, x, y, etc.
 	INT    = "INT"   // 123456
 	STRING = "STRING"
-	PERIOD = "."
+	DOT    = "."
 
 	// Operators
 	ASSIGN   = "="

--- a/token/token.go
+++ b/token/token.go
@@ -13,7 +13,6 @@ const (
 	IDENT  = "IDENT" // add, foobar, x, y, etc.
 	INT    = "INT"   // 123456
 	STRING = "STRING"
-	DOT    = "."
 
 	// Operators
 	ASSIGN   = "="
@@ -31,6 +30,7 @@ const (
 	COMMA     = ","
 	SEMICOLON = ";"
 	COLON     = ":"
+	DOT       = "."
 
 	//parenthesis + brackets
 	LPAREN   = "("

--- a/token/token.go
+++ b/token/token.go
@@ -13,6 +13,7 @@ const (
 	IDENT  = "IDENT" // add, foobar, x, y, etc.
 	INT    = "INT"   // 123456
 	STRING = "STRING"
+	PERIOD = "."
 
 	// Operators
 	ASSIGN   = "="


### PR DESCRIPTION
Alter the interpreter so we can call functions like this:
`arr.slice(...), hash.delete(...)`, as opposed to `slice(arr, ...), delete(hash, ...)`